### PR TITLE
Branch defect mongo db conn creds string invalid

### DIFF
--- a/ArdaQBWS/QBWebService.asmx.cs
+++ b/ArdaQBWS/QBWebService.asmx.cs
@@ -432,7 +432,7 @@ string message = {3}
             var appcredentials = string.Empty;
             if (!String.IsNullOrEmpty(Settings.Default.appusername) && !String.IsNullOrEmpty(Settings.Default.appuserpassword))
             {
-                appcredentials = string.Format("{0}:{1}", Settings.Default.appusername,
+                appcredentials = string.Format("{0}:{1}@", Settings.Default.appusername,
                 CryptographyHelper.Decrypt(Settings.Default.appuserpassword , cryptokey));
             }
 
@@ -447,7 +447,7 @@ string message = {3}
             }
 
             //host server
-            var connectionString = string.Format("mongodb://{0}@{1}{2}",
+            var connectionString = string.Format("mongodb://{0}{1}{2}",
                 appcredentials,
                 Settings.Default.dbhostaddress, 
                 dbhostport );


### PR DESCRIPTION
MongoDB Connection String: '@' sign still persists when no credentias are defined in configuration
